### PR TITLE
Update entrypoint.sh

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -16,6 +16,4 @@ cd ${STARMADE_HOME}/server && \
 
 chown -R starmade:starmade ${STARMADE_HOME} && \
   cd ${STARMADE_HOME}/server/StarMade && \
-  chmod ug+x ./StarMade-dedicated-server-linux.sh && \
-  ./StarMade-dedicated-server-linux.sh
-
+  java -Xms128m -Xmx1024m -jar StarMade.jar -server


### PR DESCRIPTION
Since the StarMade-Starter no longer downloads the dedicated server script(ie. https://github.com/Schine/server/blob/master/starmade/StarMade/StarMade-dedicated-server-linux.sh), we can add the script content directly to this entrypoint script.